### PR TITLE
Fixes #5 - make functions

### DIFF
--- a/dado/dado.py
+++ b/dado/dado.py
@@ -28,6 +28,7 @@ Namer: soapko
 import sys
 from functools import partial
 import inspect
+import types
 
 
 # [ Interactors ]
@@ -61,7 +62,10 @@ def dd_decorator(names, test_dict, test, build_test=build_test, get_module=get_m
     """
     for suffix, args in test_dict.items():
         new_test, new_name = build_test(test, suffix, names, args)
-        setattr(get_module(), new_name, new_test)
+        new_test.__name__ = new_name
+        new_test.__code__ = types.SimpleNamespace()
+        new_test.__code__.co_filename = test.__code__.co_filename
+        get_module().__dict__[new_name] = new_test
     # return None so that the original function will be overwritten
     # by a non-callable, and therefor will be ignored by foot.
     return None

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 # [ Main ]
 setup(
     name='dado',
-    version='0.1.1',
+    version='0.1.2',
     description='Dado: Data Driven Test Decorator.',
     url='https://github.com/notion/dado',
     author='toejough',


### PR DESCRIPTION
**Problem:**
Tools that inspect code expect certain function properties, like name
and file, which are not present in the partials that dado creates.

**Analysis:**
Could return actual functions, but these fields in functions are
read-only, so a viable alternative is ot set those fields on the
partial.

**Resolution:**
Set the expected fields on the partial.

**Testing:**
Ran tests with the newly generated functions.

**Documentation:**
None.

**Impact:**
Patch - minor bugfix update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/notion/dado/8)
<!-- Reviewable:end -->
